### PR TITLE
new samples for opc-ua

### DIFF
--- a/output/wanted_results/agent_rxta_ARTI_Sim_01.py
+++ b/output/wanted_results/agent_rxta_ARTI_Sim_01.py
@@ -1,0 +1,30 @@
+import asyncio
+from logging import setLogRecordFactory
+import robXTask.rxtx_helpers as rxtx_helpers
+
+import rxta_ARTI_Sim as rxta_ARTI_Sim
+
+# sample messagehandler for message-type 'SampleMessageType' - you get a 'paho-mqtt-message' (also holds the 'robxtask'-specific topic...)
+async def on_rxte__message__FetchDrink__rxtx_helpers(messages):
+    async for message in messages:
+        await rxtx_helpers.logMessageReceived(message)
+        print("*** on_rxte__message__FetchWater__rxtx_helpers()")
+        sDrink = str(message.payload.decode("utf-8")).strip()
+        print("got Message: " + sDrink)
+        await rxtx_helpers.log(rxtx_helpers.enLogType.BLOCKLY,"rxta_ARTI_Sim.MoveToLocationARTI(Goal_Roboter)")
+        await rxta_ARTI_Sim.MoveToLocationARTI("Goal_Roboter")
+        await rxtx_helpers.sendMessage("GrabDrink", sDrink)
+
+
+async def on_rxte__message__DrinkGrabbed__rxtx_helpers(messages):
+    async for message in messages:
+        await rxtx_helpers.logMessageReceived(message)
+        print("*** on_rxte__message__DrinkGrabbed__rxtx_helpers()")
+        sDrink = str(message.payload.decode("utf-8")).strip()
+        print("got Message: " + sDrink)
+        await rxtx_helpers.log(rxtx_helpers.enLogType.BLOCKLY,"rxta_ARTI_Sim.MoveToLocationARTI(Goal_Couch)")
+        await rxta_ARTI_Sim.MoveToLocationARTI("Goal_Couch")
+        await rxtx_helpers.sendMessage("DrinkFetched", sDrink)
+
+
+rxtx_helpers.startAsync()

--- a/output/wanted_results/agent_rxta_ARTI_Sim_01.py
+++ b/output/wanted_results/agent_rxta_ARTI_Sim_01.py
@@ -4,6 +4,10 @@ import robXTask.rxtx_helpers as rxtx_helpers
 
 import rxta_ARTI_Sim as rxta_ARTI_Sim
 
+async def startRobXTask():
+  print("*** startRobXTask")
+  # This is the main-code - place any startup things here as needed...
+
 # sample messagehandler for message-type 'SampleMessageType' - you get a 'paho-mqtt-message' (also holds the 'robxtask'-specific topic...)
 async def on_rxte__message__FetchDrink__rxtx_helpers(messages):
     async for message in messages:

--- a/output/wanted_results/rxta_ARTI_Sim.py
+++ b/output/wanted_results/rxta_ARTI_Sim.py
@@ -1,0 +1,110 @@
+import asyncio
+import robXTask.rxtx_xrob_opcua as rxtx_xrob_opcua;
+from opcua import ua
+from enum import Enum
+from functools import wraps
+
+CONST_XROB_OPCUAIP = "opc.tcp://localhost:4840"
+
+class enVariables(dict, Enum):
+    MoveToLocationARTI_State = {"id": "ns=1;s=MoveToLocationARTI:State", "varianttype" : ua.VariantType.Int32 },
+    fromSimulationARTI_AGVPositionTheta = {"id": "ns=1;s=fromSimulationARTI:AGVPositionTheta", "varianttype" : ua.VariantType.Double },
+    fromSimulationARTI_AGVPositionX = {"id": "ns=1;s=fromSimulationARTI:AGVPositionX", "varianttype" : ua.VariantType.Double },
+    fromSimulationARTI_AGVPositionY = {"id": "ns=1;s=fromSimulationARTI:AGVPositionY", "varianttype" : ua.VariantType.Double },
+    fromSimulationARTI_BatteryState = {"id": "ns=1;s=fromSimulationARTI:BatteryState", "varianttype" : ua.VariantType.Double },
+    fromSimulationARTI_ErrorMessage = {"id": "ns=1;s=fromSimulationARTI:ErrorMessage", "varianttype" : ua.VariantType.String },
+    fromSimulationARTI_HasErrorOccurred = {"id": "ns=1;s=fromSimulationARTI:HasErrorOccurred", "varianttype" : ua.VariantType.Boolean },
+    fromSimulationARTI_HasTargetGoalReached = {"id": "ns=1;s=fromSimulationARTI:HasTargetGoalReached", "varianttype" : ua.VariantType.Boolean },
+    fromSimulationARTI_LastReachedGoalName = {"id": "ns=1;s=fromSimulationARTI:LastReachedGoalName", "varianttype" : ua.VariantType.String },
+    toSimulationARTI_GetBatteryState = {"id": "ns=1;s=toSimulationARTI:GetBatteryState", "varianttype" : ua.VariantType.Boolean },
+    toSimulationARTI_MoveToTargetGoal = {"id": "ns=1;s=toSimulationARTI:MoveToTargetGoal", "varianttype" : ua.VariantType.Boolean },
+    toSimulationARTI_TargetGoalName = {"id": "ns=1;s=toSimulationARTI:TargetGoalName", "varianttype" : ua.VariantType.String },
+
+EVENT_HANDLERS_SUPPORTED = {
+    "varchange": enVariables
+}
+
+# decorator that doesn't change the decorated method in any way but tell us that we shall export this function for Blockly
+# Our Generator tool later searches for '__IsBlockly__' attribute on the function to find out what functions shall be exported
+# see: 'The best explanation of Python decorators' -> https://gist.github.com/Zearin/2f40b7b9cfc51132851a
+def blockly(func):
+    func.__IsBlockly__ = True
+    return func
+
+# this is a blockly skill - decorate this when implementing a robotic skill
+def blocklySkill(func):
+    func.__IsBlockly__ = True
+    func.__IsBlocklySkill__ = True
+    return func
+
+# decorator to specify that this is a blockly EventHandler, also holds the arguments to be expected by the EventHandler by the Python function e.g. 'sName: str, oData : str'
+# this information can be used to implement a concrete eventhandler. 
+# usually you should use an enum as first part ot the function you tag HERE to support good eventhandlers. and the second argument should be the concrete mainfunction to call using 'sEventArgs'
+# in blockly then these argments will be given as blockly-variables to the event-function
+# see: https://towardsdatascience.com/tearing-the-mask-off-python-decorators-c964344853c3
+def blocklyEventHandler(sEventArgs):
+    def decorator(func):
+        func.__IsBlockly__ = True
+        func.__IsBlocklyEventHandler__ = True
+        func.__BlocklyEventArgs__ = sEventArgs        
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
+            return result
+        return wrapper
+    return decorator
+
+# mode init code - not to export on blockly
+async def initModule(*args, **kwargs):
+    print("rxta_ARTI_Panda_Sim.initModule()")
+
+
+# mode exit code - not to export on blockly
+async def exitModule():
+    print("rxta_ARTI_Panda_Sim.exitModule()")
+
+# we remind the last result of a skill call
+GLOBAL_LastSkillCallResult = False
+
+
+@blockly
+async def getResultBool() -> bool:
+    """Returns the last Result of a skill-call as a bool"""
+    return (str(GLOBAL_LastSkillCallResult) == "True")
+
+
+@blockly
+async def getResult():
+    """Returns the last Result of a skill-call"""
+    return GLOBAL_LastSkillCallResult
+
+
+@blocklySkill
+async def MoveToLocationARTI(sLocation: str):
+    """Calls the PlugBot OPCUA Skill 'MoveToLocationARTI' from PROFACTOR'"""
+    sFuncName:str = "rxta_ARTI_Panda_Sim.MoveToLocationARTI(" + str(sLocation) + ")"
+    global GLOBAL_LastSkillCallResult
+    print(sFuncName + "-BEGIN")
+    await asyncio.sleep(2) #zh. we just sleep for 2 seconds
+    GLOBAL_LastSkillCallResult = True
+    print(sFuncName + "-END-" + str(GLOBAL_LastSkillCallResult))
+
+
+@blockly
+async def getData(enVarName : enVariables) -> str:
+    """Returns the value for the given PlugBot OPCUA variable"""
+    return "Simulation"
+
+
+@blockly
+async def setData(enVarName : enVariables, anyValue):
+    """This method could set the value of the given PlugBot OPCUA variable (but setting variables is mostly not supported by access-restrictions)"""
+    pass
+
+@blocklyEventHandler(sEventArgs="sNewValue")
+def addVariableChangeHandler(enVarName : enVariables, oFuncForVarChange):
+    pass
+
+
+
+


### PR DESCRIPTION
We produce for any OPCUA robotic device an agent-type-stub.

(1) 'rxta_ARTI_Sim.py' = A sample of such an agent-type-stub
The agent-stub-name MUST always start with rxta_. 

(2) 'agent_rxta_ARTI_Sim_01.py' now is a concrete agent built in blockly that can use 
(a) the robotic functions of the stub.
(b) some global functions for the helper module 'rxtx_helpers'
The concrete agent-file name needs to have a special name containing the agent-stub name.
eg. for an agent file using the agent stub 'rxta_ARTI_Sim.py' the filenames must be 
agent_rxta_ARTI_Sim_0x.py - where x=1 if this is the first agent of a type used in the robotic workflow and this has to be incremented if mutliple agents of the same type are used in the workflow.

Therefore (2) must import the agent-type-stub as given in the sample and the rxtx_helpers module.
and 'import asyncio' because all our code is using this pattern.
Using (2)(b) = import  rxtx_helpers' the agent also gets access to some overall functions that can be used.
e.g. to send messages. (Send a type and a Message-String)
e.g. await rxtx_helpers.sendMessage("GrabDrink", sDrink)

Our agent sample also contains 'receive a message of a type' samples.
This is done by using special naming conventions in the functionname.
e.g. async def on_rxte__message__FetchDrink__rxtx_helpers(messages):
waits for messages of Type 'FetchDrink'.

rxtx_helpers.startAsync() later then scans the code and glues the event-handlers.
Finally it starts the 'startRobXTask():' method of the agent where someone can place initial code.

Thus such a agent code can in total have some 
* initial main function
* some event-handlers to receive messages
* event-handlers to listen for Variable-change handlers (see: addVariableChangeHandler in agent-stub-code)

The agent-stubs (1) may also contain some CONST_xxx variables, that follow a special naming convention
e.g. 
CONST_XROB_OPCUAIP = "opc.tcp://localhost:4840"

Then a config file may exist in the same folder at startup for an agent of this type
e.g. 
_config_agent_rxta_AGV_01.py.config
with content:

[rxta_ARTI]
CONST_XROB_OPCUAIP = opc.tcp://localhost:4840

So an operator can overwrite the variables value there.
This is readed then by rxtx_helpers.startAsync() which at runtime scans for the presence of such files
and then overwrites these values.

